### PR TITLE
Add `resolveImport`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Version 0.10.0.0 (2023-02-28)
+
+- Introduce `resolveImport`, and make `PkgQual` opaque.
+- Rename `tcRewriterWanteds` to `tcRewriterNewWanteds`
+  (bringing it in line with nomenclature in ghc 9.4).
+
 # Version 0.9.0.0 (2023-01-24)
 
 - Add support for GHC 9.6 and `transformers` 0.6.

--- a/examples/RewriterPlugin/plugin/RewriterPlugin.hs
+++ b/examples/RewriterPlugin/plugin/RewriterPlugin.hs
@@ -54,7 +54,9 @@ data PluginDefs =
 -- Look-up a module in a package, using their names.
 findModule :: API.MonadTcPlugin m => String -> m API.Module
 findModule modName = do
-  findResult <- API.findImportedModule ( API.mkModuleName modName ) API.NoPkgQual
+  let modlName = API.mkModuleName modName
+  pkgQual    <- API.resolveImport      modlName Nothing
+  findResult <- API.findImportedModule modlName pkgQual
   case findResult of
     API.Found _ res     -> pure res
     API.FoundMultiple _ -> error $ "RewriterPlugin: found multiple modules named " <> modName <> "."

--- a/examples/SystemF/src/SystemF/Plugin.hs
+++ b/examples/SystemF/src/SystemF/Plugin.hs
@@ -64,7 +64,9 @@ data PluginDefs =
 
 findTypesModule :: MonadTcPlugin m => m Module
 findTypesModule = do
-  findResult <- findImportedModule ( mkModuleName "SystemF.Type" ) NoPkgQual
+  let modlName = mkModuleName "SystemF.Type"
+  pkgQual    <- resolveImport      modlName Nothing
+  findResult <- findImportedModule modlName pkgQual
   case findResult of
     Found _ res     -> pure res
     FoundMultiple _ -> error $ "SystemF.Plugin: found multiple modules named SystemF.Type in the current package."

--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.9.0.0
+version:        0.10.0.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple
@@ -34,6 +34,8 @@ library
   build-depends:
     base
       >= 4.13.0 && < 4.19,
+    containers
+      >= 0.6    && < 0.7,
     ghc
       >= 8.8    && < 9.7,
     transformers

--- a/src/GHC/TcPlugin/API/Internal/Shim.hs
+++ b/src/GHC/TcPlugin/API/Internal/Shim.hs
@@ -252,8 +252,8 @@ data TcPluginRewriteResult
   --
   -- The plugin can also emit additional wanted constraints.
   | TcPluginRewriteTo
-    { tcPluginReduction :: !Reduction
-    , tcRewriterWanteds :: [Ct]
+    { tcPluginReduction    :: !Reduction
+    , tcRewriterNewWanteds :: [Ct]
     }
 
 type Rewriter = RewriteEnv -> [Ct] -> [Type] -> TcPluginM TcPluginRewriteResult
@@ -591,8 +591,8 @@ runTcPluginRewriter mbRewriter tys =
       pure ( res, s )
     case rewriteResult of
       TcPluginRewriteTo
-        { tcPluginReduction = redn
-        , tcRewriterWanteds = wanteds
+        { tcPluginReduction    = redn
+        , tcRewriterNewWanteds = wanteds
         } -> addRewriting ( Just redn ) wanteds
       TcPluginNoRewrite { }
           -> addRewriting Nothing []
@@ -668,7 +668,7 @@ rewrite_tyvar2 tv fr@(_, eq_rel) = do
                 (ReprEq, _rel)  -> rewriting_co1
                 (NomEq, NomEq)  -> rewriting_co1
                 (NomEq, ReprEq) -> mkSubCo rewriting_co1
-          return $ RTRFollowed $ mkReduction rewriting_co rhs_ty 
+          return $ RTRFollowed $ mkReduction rewriting_co rhs_ty
     _other -> return RTRNotFollowed
 
 rewrite_vector :: Kind


### PR DESCRIPTION
This also changes our definition of `PkgQual` so that prior to ghc 9.4 we do not try to resolve package names to unit ID.