### PR TITLE
Bump version bounds for GHC 9.10

### DIFF
--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.12.0.0
+version:        0.11.0.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple

--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.11.0.0
+version:        0.12.0.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple
@@ -33,11 +33,11 @@ library
 
   build-depends:
     base
-      >= 4.13.0 && < 4.20,
+      >= 4.13.0 && < 4.21,
     containers
-      >= 0.6    && < 0.7,
+      >= 0.6    && < 0.8,
     ghc
-      >= 8.8    && < 9.9,
+      >= 8.8    && < 9.11,
     transformers
       >= 0.5    && < 0.7,
 


### PR DESCRIPTION
This allows `ghc-tcplugin-api` to be built with GHC 9.10