### PR TITLE
Add GHC 9.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,32 +14,63 @@ jobs:
       matrix:
         cfg:
           - { os: ubuntu-latest  , ghc: "9.10.1"  }
-          - { os: ubuntu-latest  , ghc: "9.8.2"  }
-          - { os: ubuntu-latest  , ghc: "9.6.2"  }
-          - { os: ubuntu-latest  , ghc: "9.4.7"  }
-          - { os: ubuntu-latest  , ghc: "9.2.8"  }
-          - { os: ubuntu-latest  , ghc: "9.0.2"  }
-          - { os: ubuntu-latest  , ghc: "8.10.7" }
-          - { os: ubuntu-latest  , ghc: "8.8.4"  }
+          - { os: ubuntu-latest  , ghc: "9.8.2"   }
+          - { os: ubuntu-latest  , ghc: "9.6.2"   }
+          - { os: ubuntu-latest  , ghc: "9.4.7"   }
+          - { os: ubuntu-latest  , ghc: "9.2.8"   }
+          - { os: ubuntu-latest  , ghc: "9.0.2"   }
+          - { os: ubuntu-latest  , ghc: "8.10.7"  }
+          - { os: ubuntu-latest  , ghc: "8.8.4"   }
           - { os: macOS-latest   , ghc: "9.10.1"  }
           - { os: windows-latest , ghc: "9.10.1"  }
 
     steps:
-    - name: Checkout commit
-      uses: actions/checkout@v3
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+      - uses: actions/checkout@v4
 
-    - name: Set up GHC & cabal
-      uses: haskell/actions/setup@v2
-      with:
-        ghc-version: ${{ matrix.cfg.ghc }}
-        cabal-version: ${{ matrix.cfg.cabal }}
+      - name: Set up GHC ${{ matrix.cfg.ghc }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.cfg.ghc }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
 
-    - name: Build ghc-tcplugin-api
-      run: cabal build ghc-tcplugin-api
+      - name: Configure the build
+        run: |
+          cabal configure --disable-documentation
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
 
-    - name: Build and lint System F example
-      # Skip this test on GHC 8.8.4: we need StandaloneKindSignatures.
-      if: matrix.cfg.ghc != '8.8.4'
-      working-directory: ./examples/SystemF
-      run: cabal build system-f
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build ghc-tcplugin-api
+        run: cabal build ghc-tcplugin-api
+
+      - name: Build and lint System F example
+        # Skip this test on GHC 8.8.4: we need StandaloneKindSignatures.
+        if: matrix.cfg.ghc != '8.8.4'
+        working-directory: ./examples/SystemF
+        run: cabal build system-f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,16 @@ jobs:
     strategy:
       matrix:
         cfg:
+          - { os: ubuntu-latest  , ghc: "9.10.1"  }
+          - { os: ubuntu-latest  , ghc: "9.8.2"  }
           - { os: ubuntu-latest  , ghc: "9.6.2"  }
           - { os: ubuntu-latest  , ghc: "9.4.7"  }
           - { os: ubuntu-latest  , ghc: "9.2.8"  }
-          - { os: ubuntu-latest  , ghc: "9.2.3"  }
           - { os: ubuntu-latest  , ghc: "9.0.2"  }
           - { os: ubuntu-latest  , ghc: "8.10.7" }
           - { os: ubuntu-latest  , ghc: "8.8.4"  }
-          - { os: macOS-latest   , ghc: "9.6.2"  }
-          - { os: windows-latest , ghc: "9.6.2"  }
+          - { os: macOS-latest   , ghc: "9.10.1"  }
+          - { os: windows-latest , ghc: "9.10.1"  }
 
     steps:
     - name: Checkout commit

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# Version 0.12.0.0 (2024-22-10)
+
+- Add support for GHC 9.12.
+
+- `mkPluginUnivCo`, `mkPluginUnivEvTerm` and `mkTyFamAppReduction` now all take
+  an additional `DVarSet` argument which allows specifying evidence that we
+  depend on. This stops evidence terms being floated out past used enclosing
+  Givens (see [GHC issue #23923](https://gitlab.haskell.org/ghc/ghc/-/issues/23923)).
+
+- Re-export `DVarSet`, `emptyDVarSet`, `extendDVarSet`, `unionDVarSet`
+  `unitDVarSet`, and `mkDVarSet`, as well as `ctEvId`, in order to facilitate
+  construction and manipulation of `DVarSet`s.
+
+- Re-export `GHC.Types.Unique.Set`, `GHC.Types.Unique.DSet`.
+
 # Version 0.11.0.0 (2023-08-29)
 
 - Add support for GHC 9.8.

--- a/examples/RewriterPlugin/plugin/RewriterPlugin.hs
+++ b/examples/RewriterPlugin/plugin/RewriterPlugin.hs
@@ -104,7 +104,7 @@ rewrite_add pluginDefs@( PluginDefs { .. } ) _givens tys
       -> do
           wanted <- mkCancellableWanted pluginDefs b
           pure $ API.TcPluginRewriteTo
-                  ( API.mkTyFamAppReduction "RewriterPlugin" API.Nominal addTyCon tys b )
+                  ( API.mkTyFamAppReduction "RewriterPlugin" API.Nominal API.emptyVarSet addTyCon tys b )
                   [ wanted ]
       -- "Add a Zero = a", emitting a "Cancellable a" Wanted constraint.
       | Just ( zero, [] ) <- API.splitTyConApp_maybe b
@@ -112,7 +112,7 @@ rewrite_add pluginDefs@( PluginDefs { .. } ) _givens tys
       -> do
         wanted <- mkCancellableWanted pluginDefs a
         pure $ API.TcPluginRewriteTo
-                  ( API.mkTyFamAppReduction "RewriterPlugin" API.Nominal addTyCon tys a )
+                  ( API.mkTyFamAppReduction "RewriterPlugin" API.Nominal API.emptyVarSet addTyCon tys a )
                   [ wanted ]
 
       -- Erroring on 'BadNat'.
@@ -137,7 +137,7 @@ rewrite_add pluginDefs@( PluginDefs { .. } ) _givens tys
   = pure API.TcPluginNoRewrite
   where
     badRedn :: API.Reduction
-    badRedn = API.mkTyFamAppReduction "RewriterPlugin" API.Nominal
+    badRedn = API.mkTyFamAppReduction "RewriterPlugin" API.emptyVarSet API.Nominal
       addTyCon tys (API.mkTyConApp badNatTyCon [])
 
 -- Given the type "a", constructs a "Cancellable a" constraint

--- a/examples/SystemF/src/SystemF/Examples.hs
+++ b/examples/SystemF/src/SystemF/Examples.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Haskell2010 #-}
 
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE GADTs                    #-}
 {-# LANGUAGE PolyKinds                #-}
@@ -7,6 +8,10 @@
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeOperators            #-}
+
+#if MIN_VERSION_ghc(9,9,0)
+{-# LANGUAGE TypeAbstractions #-}
+#endif
 
 module SystemF.Examples where
 
@@ -47,7 +52,11 @@ type ChurchKind :: Kind -> Kind
 type ChurchKind k = Fun (Fun k k) (Fun k k)
 
 type ChurchType :: forall (k :: Kind). Type KEmpty (ChurchKind k)
-type ChurchType = Forall ( (VarTy KZ :-> VarTy KZ) :-> (VarTy KZ :-> VarTy KZ) )
+type ChurchType
+#if MIN_VERSION_ghc(9,9,0)
+  @k
+#endif
+  = Forall ( (VarTy KZ :-> VarTy KZ) :-> (VarTy KZ :-> VarTy KZ) )
 
 church :: forall (k :: Kind). Hs.Int -> Term Empty (ChurchType @k)
 church i = TyLam $ LamE ( SVarTy SKZ :%-> SVarTy SKZ ) $ LamE ( SVarTy SKZ ) ( go i )

--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.11.0.0
+version:        0.12.0.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple
@@ -33,11 +33,11 @@ library
 
   build-depends:
     base
-      >= 4.13.0 && < 4.21,
+      >= 4.13.0 && < 4.22,
     containers
       >= 0.6    && < 0.8,
     ghc
-      >= 8.8    && < 9.11,
+      >= 8.8    && < 9.13,
     transformers
       >= 0.5    && < 0.7,
 
@@ -68,6 +68,8 @@ library
     , GHC.Plugins
     , GHC.Types.Unique.DFM
     , GHC.Types.Unique.FM
+    , GHC.Types.Unique.Set
+    , GHC.Types.Unique.DSet
     , GHC.Utils.Outputable
 
   if impl(ghc >= 9.3.0)
@@ -126,7 +128,9 @@ library
         , SrcLoc     as GHC.Types.SrcLoc
         , Unique     as GHC.Types.Unique
         , UniqDFM    as GHC.Types.Unique.DFM
+        , UniqDSet   as GHC.Types.Unique.DSet
         , UniqFM     as GHC.Types.Unique.FM
+        , UniqSet    as GHC.Types.Unique.Set
         , Var        as GHC.Types.Var
         , VarEnv     as GHC.Types.Var.Env
         , VarSet     as GHC.Types.Var.Set


### PR DESCRIPTION
This adds support for GHC 9.12 and changes the interface to require passing a `DCoVarSet` of coercions we depend on when generating a proof term.