### PR TITLE
v0.14.0.0: mkEqPredRole renaming

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
-# Version 0.13.0.0 (2024-30-10)
+
+# Version 0.14.0.0 (2024-11-28)
+
+- Rename `mkPrimEqPredRole` to `mkEqPredRole`. This is a re-exported function
+  from GHC, and the renaming adapts to the renaming in GHC-9.13.
+
+# Version 0.13.0.0 (2024-10-30)
 
 - Update to changes in the type of GHC's `mkUnivCo`
   in order to (properly) add support for GHC 9.12.
@@ -14,7 +20,7 @@
 
 - Re-export `ctEvCoercion`, and stop re-exporting `ctEvId`.
 
-# Version 0.12.0.0 (2024-22-10)
+# Version 0.12.0.0 (2024-10-22)
 
 - Add preliminary support for GHC 9.12.
 

--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.13.0.0
+version:        0.14.0.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple

--- a/src/GHC/TcPlugin/API.hs
+++ b/src/GHC/TcPlugin/API.hs
@@ -322,7 +322,7 @@ module GHC.TcPlugin.API
 
     -- | The following functions allow plugins to create constraints
     -- for typeclasses and type equalities.
-  , mkClassPred, mkPrimEqPredRole
+  , mkClassPred, mkEqPredRole
 
     -- | === Deriveds
 
@@ -516,7 +516,7 @@ import GHC.Core.Class
 import GHC.Core.Coercion
   ( mkReflCo, mkSymCo, mkTransCo
   , mkUnivCo
-#if MIN_VERSION_ghc(8,10,0)
+#if !MIN_VERSION_ghc(9,13,0) && MIN_VERSION_ghc(8,10,0)
   , mkPrimEqPredRole
 #endif
   )
@@ -536,6 +536,9 @@ import GHC.Core.Make
 #endif
 import GHC.Core.Predicate
   ( EqRel(..)
+#if MIN_VERSION_ghc(9,13,0)
+  , mkEqPredRole
+#endif
 #if MIN_VERSION_ghc(8,10,0)
   , Pred(..)
 #else
@@ -1111,12 +1114,21 @@ mkVisFunTysMany = mkFunTys
 mkPiTy :: TyCoBinder -> Type -> Type
 mkPiTy bndr ty = mkPiTys [bndr] ty
 
--- | Makes a lifted equality predicate at the given role
-mkPrimEqPredRole :: Role -> Type -> Type -> PredType
-mkPrimEqPredRole Nominal          = mkPrimEqPred
-mkPrimEqPredRole Representational = mkReprPrimEqPred
-mkPrimEqPredRole Phantom          = panic "mkPrimEqPredRole phantom"
+#endif
+#endif
 
+--------------------------------------------------------------------------------
+
+#if !MIN_VERSION_ghc(9,13,0)
+-- | Makes an unlifted equality predicate at the given role
+-- (either 'Nominal' or 'Representational').
+mkEqPredRole :: Role -> Type -> Type -> PredType
+#if MIN_VERSION_ghc(8,10,0)
+mkEqPredRole = mkPrimEqPredRole
+#else
+mkEqPredRole Nominal          = mkPrimEqPred
+mkEqPredRole Representational = mkReprPrimEqPred
+mkEqPredRole Phantom          = panic "mkPrimEqPredRole phantom"
 #endif
 #endif
 


### PR DESCRIPTION
This PR adapts to the renaming of `mkPrimEqPredRole` to `mkEqPredRole` in GHC 9.13.