### PR TITLE
Fix bug in constructEquivClasses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+
+# Version 0.17.1.0 (2025-08-27)
+
+- Fix a regression, introduced in `0.17.0.0`, in which `splitTyConApp_upTo` would
+  fail to take into account equalities of the form `tv1 ~ tv2`.
+
 # Version 0.17.0.0 (2025-08-25)
 
 - `splitTyConApp_upTo` now additionally returns a `[Coercion]` for tracking

--- a/ghc-tcplugin-api.cabal
+++ b/ghc-tcplugin-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:  3.0
 name:           ghc-tcplugin-api
-version:        0.17.0.0
+version:        0.17.1.0
 synopsis:       An API for type-checker plugins.
 license:        BSD-3-Clause
 build-type:     Simple


### PR DESCRIPTION
This fixes a bug in `constructEquivClasses` in which we failed to use equivalences in both directions. It also refactors that function to use `IntMap`s rather than `Map`s. For the case we were working with, `TyVar`s, we were already comparing based on the `Unique`s, so we might as well use the appropriate data structures.